### PR TITLE
Adding pytest to parcels-feedstock recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 418489ce9a58da2268d050fbc64638ad20fbcc58dd54731b3c9814cccbdf447c
 
 build:
-  number: 1
+  number: 2
   script:
     - {{ PYTHON }} setup.py bdist_wheel --dist-dir=dist
     - {{ PYTHON }} -m pip install --find-links=dist --no-deps --ignore-installed --no-cache-dir -vvv {{ name }}
@@ -41,6 +41,7 @@ requirements:
     - numpy >=1.11  # [win]
     - progressbar2
     - pymbolic
+    - pytest
     - python-dateutil
     - scipy >=0.16.0
     - six >=1.10.0


### PR DESCRIPTION
Since `pytest` is needed for the `example_peninsula.py` testcase that is mentioned in the Parcels installation instructions at step 5 of https://oceanparcels.org/#installing, it is good to add it as a requirement here too (it is already a requirement in https://github.com/OceanParcels/parcels/blob/master/environment_py3_linux.yml#L29).