### PR TITLE
Update matplotlib-base as dependency in meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - gcc_linux-64  # [linux]
     - clang_osx-64  # [osx]
     - m2w64-toolchain  # [win]
-    - matplotlib >=2.0.2
+    - matplotlib-base >=2.0.2
     - netcdf4 >=1.1.9
     - numpy >=1.9  # [linux64 or osx]
     - numpy >=1.11  # [win]


### PR DESCRIPTION
Changing to matplotlib-base dependency, as suggested by https://github.com/pangeo-data/pangeo-docker-images/issues/329 and also implemented within Parcels itself in https://github.com/OceanParcels/parcels/pull/1174